### PR TITLE
bump Jekyll version >= 3.6.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     github-pages (139)
       activesupport (= 4.2.8)
       github-pages-health-check (= 1.3.3)
-      jekyll (= 3.4.3)
+      jekyll (>= 3.6.3)
       jekyll-avatar (= 0.4.2)
       jekyll-coffeescript (= 1.0.1)
       jekyll-default-layout (= 0.1.4)


### PR DESCRIPTION
based on reported security vulnerability. the Jekyll version no is bumped up